### PR TITLE
Fix version conflicts caused by PR#95

### DIFF
--- a/src/Proventos.Api/Proventos.Api.csproj
+++ b/src/Proventos.Api/Proventos.Api.csproj
@@ -9,13 +9,13 @@
     <PackageReference Include="MediatR" Version="8.0.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.8" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.AspNetCore.Authentication.JwtBearer from 3.1.5 to 5.0.8. [(PR#95)](https://github.com/juniosilvac/Proventos/pull/95).
Hope this fix can help you.

Best regards,
sucrose